### PR TITLE
ci: pin version of third party actions

### DIFF
--- a/default.json
+++ b/default.json
@@ -27,12 +27,8 @@
   "packageRules": [
     {
       // Third party actions should be pinned with digest
-      "matchDepTypes": [
-        "action"
-      ],
-      excludePackagePrefixes: [
-        "actions/"
-      ],
+      "matchDepTypes": ["action"],
+      "excludePackagePrefixes": ["actions/"],
       "pinDigests": true
     }
   ]

--- a/default.json
+++ b/default.json
@@ -23,5 +23,17 @@
   "npm": {
     "extends": ["npm:unpublishSafe", "helpers:disableTypesNodeMajor"],
     "postUpdateOptions": ["npmDedupe"]
-  }
+  },
+  "packageRules": [
+    {
+      // Third party actions should be pinned with digest
+      "matchDepTypes": [
+        "action"
+      ],
+      excludePackagePrefixes: [
+        "actions/"
+      ],
+      "pinDigests": true
+    }
+  ]
 }


### PR DESCRIPTION
## Why

To use digest pinning but want to follow the action version tag on updating third-party actions

## What

- Specify version to third-party actions

https://docs.renovatebot.com/modules/manager/github-actions/#additional-information
https://zenn.dev/roottool/scraps/5a73b98e88d4d1